### PR TITLE
Modify throttle API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lib-wc"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2021"
 readme = "README.md"
 description = "Will's Programming Toolbox"

--- a/experiments/tokio-graceful-shutdown/Cargo.lock
+++ b/experiments/tokio-graceful-shutdown/Cargo.lock
@@ -254,24 +254,21 @@ dependencies = [
 
 [[package]]
 name = "lib-wc"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "anyhow",
  "atomic-wait",
  "bincode",
  "crossbeam",
  "crossbeam-epoch",
- "crossbeam-utils",
  "dashmap",
  "futures",
  "log",
- "once_cell",
  "rand",
  "rayon",
  "serde",
  "serde_derive",
  "tokio",
- "tokio-retry",
 ]
 
 [[package]]
@@ -363,26 +360,6 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "pin-project"
-version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -587,17 +564,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tokio-retry"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
-dependencies = [
- "pin-project",
- "rand",
- "tokio",
 ]
 
 [[package]]

--- a/experiments/tokio-graceful-shutdown/Cargo.toml
+++ b/experiments/tokio-graceful-shutdown/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-lib-wc = { path = "../..", features = ["default"] }
+lib-wc = { path = "../.." }
 tokio = { version = "1.25.0", features = ["full"] }

--- a/src/concurrent/sync/rate_limiter/multi.rs
+++ b/src/concurrent/sync/rate_limiter/multi.rs
@@ -1,6 +1,5 @@
 use crate::sync::backoff::Backoff;
 use crate::sync::RateLimiter;
-use anyhow::Result;
 use std::hash::Hash;
 use std::time::Duration;
 
@@ -80,10 +79,10 @@ impl<K: Eq + Hash + Clone> MultiRateLimiter<K> {
     ///
     /// async fn do_work() { /* some computation */ }
     ///
-    /// async fn throttle_by_key(the_key: u32, limiter: Arc<MultiRateLimiter<u32>>) -> Result<()> {
+    /// async fn throttle_by_key(the_key: u32, limiter: Arc<MultiRateLimiter<u32>>) {
     ///    limiter.throttle(the_key, || do_work()).await
     /// }
-    pub async fn throttle<Fut, F, T>(&self, key: K, f: F) -> Result<T>
+    pub async fn throttle<Fut, F, T>(&self, key: K, f: F) -> T
     where
         Fut: std::future::Future<Output = T>,
         F: FnOnce() -> Fut,
@@ -104,6 +103,7 @@ impl<K: Eq + Hash + Clone> MultiRateLimiter<K> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use anyhow::Result;
     use futures::future::join_all;
     use std::ops::Mul;
     use std::sync::atomic::AtomicUsize;
@@ -122,7 +122,7 @@ mod tests {
                 .throttle("key", || async {
                     COUNT.fetch_add(1, SeqCst);
                 })
-                .await?;
+                .await;
         }
 
         assert_eq!(COUNT.load(SeqCst), 10);
@@ -142,7 +142,7 @@ mod tests {
                 .throttle(k, || async {
                     COUNT.fetch_add(1, SeqCst);
                 })
-                .await?;
+                .await;
         }
 
         assert_eq!(COUNT.load(SeqCst), 10);
@@ -163,7 +163,7 @@ mod tests {
                     .throttle("key", || async {
                         COUNT.fetch_add(1, SeqCst);
                     })
-                    .await?;
+                    .await;
                 Ok::<(), anyhow::Error>(())
             })
         }))
@@ -188,7 +188,7 @@ mod tests {
                     .throttle(x, || async {
                         COUNT.fetch_add(1, SeqCst);
                     })
-                    .await?;
+                    .await;
                 Ok::<(), anyhow::Error>(())
             })
         }))
@@ -216,7 +216,7 @@ mod tests {
                     .throttle(target, || async {
                         COUNT.fetch_add(1, SeqCst);
                     })
-                    .await?;
+                    .await;
                 Ok::<(), anyhow::Error>(())
             })
         }))


### PR DESCRIPTION
## Old

```rs
    pub async fn throttle<Fut, F, T>(&self, f: F) -> Result<T>
    where
        Fut: std::future::Future<Output = T>,
        F: FnOnce() -> Fut,
    {
        self.wait().await;
        Ok(f().await)
    }
```

## New

```rs
    pub async fn throttle<Fut, F, T>(&self, f: F) -> T
    where
        Fut: std::future::Future<Output = T>,
        F: FnOnce() -> Fut,
    {
        self.wait().await;
        f().await
    }
```